### PR TITLE
glibc2.31-stime: Fix build on glibc>=2.31 by replacing stime() with c…

### DIFF
--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -8861,10 +8861,11 @@ abi_long do_syscall(void *cpu_env, int num, abi_long arg1,
 #ifdef TARGET_NR_stime /* not on alpha */
     case TARGET_NR_stime:
         {
-            time_t host_time;
-            if (get_user_sal(host_time, arg1))
+            struct timespec ts;
+            ts.tv_nsec = 0;
+            if (get_user_sal(ts.tv_sec, arg1))
                 goto efault;
-            ret = get_errno(stime(&host_time));
+            ret = get_errno(clock_settime(CLOCK_REALTIME, &ts));
         }
         break;
 #endif


### PR DESCRIPTION
…lock_settime().

The obsolete function stime is no longer available to newly linked
binaries, and its declaration has been removed from <time.h>.
Programs that set the system time should use clock_settime instead.

https://lwn.net/Articles/811275/
https://linux.die.net/man/3/clock_settime