### PR TITLE
Fix build on glibc 2.36

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,48 +1,48 @@
 [submodule "roms/vgabios"]
 	path = roms/vgabios
-	url = git://gitlab.com/qemu-project/vgabios.git/
+	url = https://gitlab.com/qemu-project/vgabios.git/
 [submodule "roms/seabios"]
 	path = roms/seabios
-	url = git://gitlab.com/qemu-project/seabios.git/
+	url = https://gitlab.com/qemu-project/seabios.git/
 [submodule "roms/SLOF"]
 	path = roms/SLOF
-	url = git://gitlab.com/qemu-project/SLOF.git
+	url = https://gitlab.com/qemu-project/SLOF.git
 [submodule "roms/ipxe"]
 	path = roms/ipxe
-	url = git://gitlab.com/qemu-project/ipxe.git
+	url = https://gitlab.com/qemu-project/ipxe.git
 [submodule "roms/openbios"]
 	path = roms/openbios
-	url = git://gitlab.com/qemu-project/openbios.git
+	url = https://gitlab.com/qemu-project/openbios.git
 [submodule "roms/openhackware"]
 	path = roms/openhackware
-	url = git://gitlab.com/qemu-project/openhackware.git
+	url = https://gitlab.com/qemu-project/openhackware.git
 [submodule "roms/qemu-palcode"]
 	path = roms/qemu-palcode
-	url = git://github.com/rth7680/qemu-palcode.git
+	url = https://github.com/rth7680/qemu-palcode.git
 [submodule "roms/sgabios"]
 	path = roms/sgabios
-	url = git://gitlab.com/qemu-project/sgabios.git
+	url = https://gitlab.com/qemu-project/sgabios.git
 [submodule "dtc"]
 	path = dtc
-	url = git://gitlab.com/qemu-project/dtc.git
+	url = https://gitlab.com/qemu-project/dtc.git
 [submodule "roms/u-boot"]
 	path = roms/u-boot
-	url = git://gitlab.com/qemu-project/u-boot.git
+	url = https://gitlab.com/qemu-project/u-boot.git
 [submodule "roms/skiboot"]
 	path = roms/skiboot
-	url = git://gitlab.com/qemu-project/skiboot.git
+	url = https://gitlab.com/qemu-project/skiboot.git
 [submodule "roms/QemuMacDrivers"]
 	path = roms/QemuMacDrivers
-	url = git://gitlab.com/qemu-project/QemuMacDrivers.git
+	url = https://gitlab.com/qemu-project/QemuMacDrivers.git
 [submodule "ui/keycodemapdb"]
 	path = ui/keycodemapdb
-	url = git://gitlab.com/qemu-project/keycodemapdb.git
+	url = https://gitlab.com/qemu-project/keycodemapdb.git
 [submodule "capstone"]
 	path = capstone
-	url = git://gitlab.com/qemu-project/capstone.git
+	url = https://gitlab.com/qemu-project/capstone.git
 [submodule "roms/seabios-hppa"]
 	path = roms/seabios-hppa
-	url = git://github.com/hdeller/seabios-hppa.git
+	url = https://github.com/hdeller/seabios-hppa.git
 [submodule "roms/u-boot-sam460ex"]
 	path = roms/u-boot-sam460ex
-	url = git://github.com/zbalaton/u-boot-sam460ex
+	url = https://github.com/zbalaton/u-boot-sam460ex

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,45 +1,45 @@
 [submodule "roms/vgabios"]
 	path = roms/vgabios
-	url = git://git.qemu-project.org/vgabios.git/
+	url = git://gitlab.com/qemu-project/vgabios.git/
 [submodule "roms/seabios"]
 	path = roms/seabios
-	url = git://git.qemu-project.org/seabios.git/
+	url = git://gitlab.com/qemu-project/seabios.git/
 [submodule "roms/SLOF"]
 	path = roms/SLOF
-	url = git://git.qemu-project.org/SLOF.git
+	url = git://gitlab.com/qemu-project/SLOF.git
 [submodule "roms/ipxe"]
 	path = roms/ipxe
-	url = git://git.qemu-project.org/ipxe.git
+	url = git://gitlab.com/qemu-project/ipxe.git
 [submodule "roms/openbios"]
 	path = roms/openbios
-	url = git://git.qemu-project.org/openbios.git
+	url = git://gitlab.com/qemu-project/openbios.git
 [submodule "roms/openhackware"]
 	path = roms/openhackware
-	url = git://git.qemu-project.org/openhackware.git
+	url = git://gitlab.com/qemu-project/openhackware.git
 [submodule "roms/qemu-palcode"]
 	path = roms/qemu-palcode
 	url = git://github.com/rth7680/qemu-palcode.git
 [submodule "roms/sgabios"]
 	path = roms/sgabios
-	url = git://git.qemu-project.org/sgabios.git
+	url = git://gitlab.com/qemu-project/sgabios.git
 [submodule "dtc"]
 	path = dtc
-	url = git://git.qemu-project.org/dtc.git
+	url = git://gitlab.com/qemu-project/dtc.git
 [submodule "roms/u-boot"]
 	path = roms/u-boot
-	url = git://git.qemu-project.org/u-boot.git
+	url = git://gitlab.com/qemu-project/u-boot.git
 [submodule "roms/skiboot"]
 	path = roms/skiboot
-	url = git://git.qemu.org/skiboot.git
+	url = git://gitlab.com/qemu-project/skiboot.git
 [submodule "roms/QemuMacDrivers"]
 	path = roms/QemuMacDrivers
-	url = git://git.qemu.org/QemuMacDrivers.git
+	url = git://gitlab.com/qemu-project/QemuMacDrivers.git
 [submodule "ui/keycodemapdb"]
 	path = ui/keycodemapdb
-	url = git://git.qemu.org/keycodemapdb.git
+	url = git://gitlab.com/qemu-project/keycodemapdb.git
 [submodule "capstone"]
 	path = capstone
-	url = git://git.qemu.org/capstone.git
+	url = git://gitlab.com/qemu-project/capstone.git
 [submodule "roms/seabios-hppa"]
 	path = roms/seabios-hppa
 	url = git://github.com/hdeller/seabios-hppa.git

--- a/configure
+++ b/configure
@@ -5138,6 +5138,20 @@ if compile_prog "" "" ; then
 fi
 
 ##########################################
+# check if sys/mount.h conflicts with linux/fs.h
+
+have_sysmount_fs=no
+cat > $TMPC << EOF
+#include <sys/mount.h>
+int main(void) {
+  return FSCONFIG_SET_FLAG;
+}
+EOF
+if compile_prog "" "" ; then
+    have_sysmount_fs=yes
+fi
+
+##########################################
 # check if rtnetlink.h exists and is useful
 have_rtnetlink=no
 cat > $TMPC << EOF
@@ -6499,6 +6513,10 @@ echo "CONFIG_TRACE_FILE=$trace_file" >> $config_host_mak
 if test "$rdma" = "yes" ; then
   echo "CONFIG_RDMA=y" >> $config_host_mak
   echo "RDMA_LIBS=$rdma_libs" >> $config_host_mak
+fi
+
+if test "$have_sysmount_fs" = "yes" ; then
+  echo "CONFIG_SYS_MOUNT_FS=y" >> $config_host_mak
 fi
 
 if test "$have_rtnetlink" = "yes" ; then

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -98,7 +98,24 @@
 #include <linux/soundcard.h>
 #include <linux/kd.h>
 #include <linux/mtio.h>
+#ifdef CONFIG_SYS_MOUNT_FS
+/*
+ * glibc >= 2.36 linux/mount.h conflicts with sys/mount.h,
+ * which in turn prevents use of linux/fs.h. So we have to
+ * define the constants ourselves for now.
+ */
+#define FS_IOC_GETFLAGS                _IOR('f', 1, long)
+#define FS_IOC_SETFLAGS                _IOW('f', 2, long)
+#define FS_IOC_GETVERSION              _IOR('v', 1, long)
+#define FS_IOC_SETVERSION              _IOW('v', 2, long)
+#define FS_IOC_FIEMAP                  _IOWR('f', 11, struct fiemap)
+#define FS_IOC32_GETFLAGS              _IOR('f', 1, int)
+#define FS_IOC32_SETFLAGS              _IOW('f', 2, int)
+#define FS_IOC32_GETVERSION            _IOR('v', 1, int)
+#define FS_IOC32_SETVERSION            _IOW('v', 2, int)
+#else
 #include <linux/fs.h>
+#endif
 #if defined(CONFIG_FIEMAP)
 #include <linux/fiemap.h>
 #endif


### PR DESCRIPTION
As of glibc version 2.36, `sys/mount.h` and `linux/mount.h` seem to conflict with each other, which breaks the `linux/fs.h` include. This PR detects if glibc's version is present and manually defines the constants used from `linux/fs.h` instead of including it.