### PR TITLE
Fix IRIX pathconf() syscall

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -36,7 +36,7 @@
 	url = git://git.qemu.org/QemuMacDrivers.git
 [submodule "ui/keycodemapdb"]
 	path = ui/keycodemapdb
-	url = git://git.qemu.org/keycodemapdb.git
+	url = https://gitlab.com/qemu-project/keycodemapdb.git
 [submodule "capstone"]
 	path = capstone
 	url = git://git.qemu.org/capstone.git

--- a/linux-user/irix/syscall_nr.h
+++ b/linux-user/irix/syscall_nr.h
@@ -247,7 +247,7 @@
 #define TARGET_NR_syssgi_setsid		(20)
 #define TARGET_NR_syssgi_setpgid	(21)
 #define TARGET_NR_syssgi_sysconf	(22)
-#define TARGET_NR_syssgi_pathconf	(23)
+#define TARGET_NR_syssgi_pathconf	(24)
 #define TARGET_NR_syssgi_setgroups	(40)
 #define TARGET_NR_syssgi_getgroups	(41)
 #define TARGET_NR_syssgi_settimeofday	(52)

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -14527,13 +14527,13 @@ abi_long do_syscall(void *cpu_env, int num, abi_long arg1,
             }
             break;
         case TARGET_NR_syssgi_pathconf:
-            if (arg3 == 1) {
-                if (!(p = lock_user_string(arg1)))
+            if (arg4 == 1) {
+                if (!(p = lock_user_string(arg2)))
                     goto efault;
-                ret = get_errno(pathconf(path(p), target_to_host_pathconf(arg2)));
+                ret = get_errno(pathconf(path(p), target_to_host_pathconf(arg3)));
                 unlock_user(p, arg1, 0);
             } else
-                ret = get_errno(fpathconf(arg1, target_to_host_pathconf(arg2)));
+                ret = get_errno(fpathconf(arg2, target_to_host_pathconf(arg3)));
             break;
         case TARGET_NR_syssgi_rusage:
             {


### PR DESCRIPTION
Currently `pathconf()` always errors in qemu, and when running IDO with `-g3` this causes it to allocate to a heap buffer with a size too small. When the compiler encounters a long path name it overflows this buffer, which can corrupt the heap and eventually lead to a segfault. Currently this prevents OOT retail versions from building with qemu-irix.

I some trouble getting this to build on modern Ubuntu. I updated a submodule path in this PR, and also had to install python2 manually. Full steps (from https://ubuntuforums.org/showthread.php?t=2486174&p=14140057#post14140057):

```
wget https://www.python.org/ftp/python/2.7.9/Python-2.7.9.tgz
sudo tar xzf Python-2.7.9.tgz
cd Python-2.7.9
sudo ./configure --enable-optimizations
sudo make altinstall
```

Then to build qemu-irix:
```
./configure --target-list=irix-linux-user --disable-werror --python=/usr/local/bin/python2.7
make
sudo make install
```